### PR TITLE
propose changes to prettier rules

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,5 @@
 {
-    "arrowParens": "avoid",
+    "arrowParens": "always",
     "bracketSpacing": true,
     "endOfLine": "lf",
     "htmlWhitespaceSensitivity": "css",
@@ -10,6 +10,6 @@
     "semi": true,
     "singleQuote": true,
     "tabWidth": 4,
-    "trailingComma": "es5",
+    "trailingComma": "none",
     "useTabs": false
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -10,6 +10,6 @@
     "semi": true,
     "singleQuote": true,
     "tabWidth": 4,
-    "trailingComma": "none",
+    "trailingComma": "es5",
     "useTabs": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
         "source.fixAll": true,
         "source.organizeImports": false
     },
+    "editor.rulers": [100],
     "eslint.enable": true,
     "eslint.validate": ["javascript", "typescript"],
     "importSorter.generalConfiguration.sortOnBeforeSave": true,

--- a/scripts/helper.js
+++ b/scripts/helper.js
@@ -6,5 +6,5 @@ import { fileURLToPath } from 'node:url';
  * @param {string} filepath - Path to a file.
  * @returns Resolved file path.
  */
-export const resolveFile = filepath =>
+export const resolveFile = (filepath) =>
     resolve(dirname(fileURLToPath(import.meta.url)), '..', filepath);

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -56,7 +56,7 @@ export class CSV {
     protected openUrl(url: string): void {
         this._options.delimiter ??= deductDelimiter(url.split('.').pop());
         const size = 'Content-Length';
-        fetch(url).then(res => {
+        fetch(url).then((res) => {
             if (res.headers.has(size)) {
                 this._options.size ??= Number.parseInt(res.headers.get(size));
             }
@@ -82,19 +82,19 @@ export class CSV {
         const h = this._handlers.get(event);
         switch (event) {
             case Event.Opened:
-                h.forEach(h => (h as OpenedHandler)(data as ColumnHeader[]));
+                h.forEach((h) => (h as OpenedHandler)(data as ColumnHeader[]));
                 break;
             case Event.Columns:
-                h.forEach(h => (h as ColumnsHandler)(data as Column[]));
+                h.forEach((h) => (h as ColumnsHandler)(data as Column[]));
                 break;
             case Event.Data:
-                h.forEach(h => (h as DataHandler)(data as number));
+                h.forEach((h) => (h as DataHandler)(data as number));
                 break;
             case Event.Done:
-                h.forEach(h => (h as DoneHandler)(data as LoadStatistics));
+                h.forEach((h) => (h as DoneHandler)(data as LoadStatistics));
                 break;
             case Event.Error:
-                h.forEach(h => (h as ErrorHandler)(data as string));
+                h.forEach((h) => (h as ErrorHandler)(data as string));
                 break;
             default:
                 break;

--- a/src/helper/remainders.ts
+++ b/src/helper/remainders.ts
@@ -23,7 +23,7 @@ export function detectRemainders(chunks: ArrayBuffer[]): RemainderInfo {
     // find first lf -> everything before is remainder
     for (let i = 0; i < chunks.length; i++) {
         const chunk = new Uint8Array(chunks[i]);
-        const lfPos = chunk.findIndex(c => c === lf);
+        const lfPos = chunk.findIndex((c) => c === lf);
 
         // no lf -> whole chunk is remainder
         if (lfPos < 0) {
@@ -62,7 +62,7 @@ export function detectRemainders(chunks: ArrayBuffer[]): RemainderInfo {
     // find last lf -> everything after is remainder
     for (let i = chunks.length - 1; i >= 0; i--) {
         const chunk = new Uint8Array(chunks[i]);
-        const lfPos = findLastIndex(chunk, c => c === lf);
+        const lfPos = findLastIndex(chunk, (c) => c === lf);
 
         // no lf -> whole chunk is remainder
         if (lfPos < 0) {

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -137,7 +137,7 @@ export class Loader {
     protected detectTypes(chunk: ArrayBufferLike): void {
         const lines = parse([chunk], { chunk: 0, char: 0 }, { chunk: 0, char: chunk.byteLength });
 
-        this._firstChunkSplit = lines.map(l => splitLine(l, this._options.delimiter));
+        this._firstChunkSplit = lines.map((l) => splitLine(l, this._options.delimiter));
 
         const inferStart = +this._options.includesHeader;
         const inferLines = this._firstChunkSplit.slice(
@@ -146,7 +146,7 @@ export class Loader {
         );
 
         const detectedTypes = inferLines
-            .map(l => l.map(c => inferType(c)))
+            .map((l) => l.map((c) => inferType(c)))
             .reduce((prev, cur) => prev.map((p, i) => lowestType(p, cur[i])));
 
         const header = detectedTypes.map((t, i) => {
@@ -168,7 +168,7 @@ export class Loader {
                     t
                 )
             ),
-            ...this._types.generatedColumns.map(t => buildColumn(t.name, t.type)),
+            ...this._types.generatedColumns.map((t) => buildColumn(t.name, t.type)),
         ];
         this._firstChunkSplit = undefined;
         this._onColumns(this._columns);
@@ -217,7 +217,7 @@ export class Loader {
     }
 
     protected onProcessed(data: ProcessedData): void {
-        const chunks = data.chunks.map(c => rebuildChunk(c));
+        const chunks = data.chunks.map((c) => rebuildChunk(c));
         this._columns.forEach((c, i) => c.push(chunks[i] as AnyChunk));
         this._onData(this._columns[0].length);
     }

--- a/src/types/column/baseColumn.ts
+++ b/src/types/column/baseColumn.ts
@@ -39,12 +39,12 @@ export abstract class BaseColumn<T, C extends BC<T>> implements IColumn<T, C> {
     }
 
     public get(index: number): T {
-        const chunk = this._chunks.find(c => c.offset < index && c.offset + c.length >= index);
+        const chunk = this._chunks.find((c) => c.offset < index && c.offset + c.length >= index);
         if (!chunk) throw new Error('Invalid index.');
         return chunk.get(index - chunk.offset);
     }
     public set(index: number, value: T): void {
-        const chunk = this._chunks.find(c => c.offset < index && c.offset + c.length >= index);
+        const chunk = this._chunks.find((c) => c.offset < index && c.offset + c.length >= index);
         if (!chunk) throw new Error('Invalid index.');
         chunk.set(index - chunk.offset, value);
     }

--- a/src/worker/main/worker.ts
+++ b/src/worker/main/worker.ts
@@ -149,8 +149,8 @@ function finishChunk(): boolean {
     if (sr) buf.set(new Uint8Array(sr), er.byteLength);
 
     handleRemainder(buf, pc, gc);
-    pc.forEach(c => (c.offset = chunkLengthSum));
-    gc.forEach(c => (c.offset = chunkLengthSum));
+    pc.forEach((c) => (c.offset = chunkLengthSum));
+    gc.forEach((c) => (c.offset = chunkLengthSum));
     chunkLengthSum += pc[0].length;
 
     parsedChunks.delete(nextChunkToBeFinished);
@@ -179,7 +179,7 @@ function handleRemainder(buf: Uint8Array, pc: Chunk[], gc: Chunk[]): void {
     values.forEach((v, vi) => storeValue(v, pc[vi].length - 1, pc[vi]));
 
     const gen = setup.generatedColumns;
-    const genValues = gen.map(g => g.func(valueTexts, values));
+    const genValues = gen.map((g) => g.func(valueTexts, values));
     genValues.forEach((v, vi) => storeValue(v, gc[vi].length - 1, gc[vi]));
 }
 

--- a/src/worker/sub/worker.ts
+++ b/src/worker/sub/worker.ts
@@ -18,20 +18,20 @@ subWorker.onmessage = (e: MessageEvent<Interface.MessageData>) => {
 
 function onStart(data: Interface.StartData): void {
     const remainders = detectRemainders(data.chunks);
-    const lines = parse(data.chunks, remainders.start, remainders.end).map(l =>
+    const lines = parse(data.chunks, remainders.start, remainders.end).map((l) =>
         splitLine(l, data.options.delimiter)
     );
 
     const numChunks = lines.length + 1; // +1 for inter-chunk remainder
-    const chunks = data.columns.map(c => buildChunk(c, numChunks));
-    const values = lines.map(l => parseLine(l, data.columns));
+    const chunks = data.columns.map((c) => buildChunk(c, numChunks));
+    const values = lines.map((l) => parseLine(l, data.columns));
     values.forEach((line, li) => line.forEach((value, vi) => storeValue(value, li, chunks[vi])));
 
     const gen = data.generatedColumns;
-    const generatedChunks = gen.map(c => buildChunk(c.type, numChunks));
+    const generatedChunks = gen.map((c) => buildChunk(c.type, numChunks));
 
     lines.forEach((line, li) => {
-        const genValues = gen.map(g => g.func(line, values[li]));
+        const genValues = gen.map((g) => g.func(line, values[li]));
         genValues.forEach((value, vi) => storeValue(value, li, generatedChunks[vi]));
     });
 

--- a/test/express/index.js
+++ b/test/express/index.js
@@ -4,7 +4,7 @@ function load(url) {
         delimiter: ',',
     };
 
-    const update = progress => {
+    const update = (progress) => {
         console.log('progress:', progress);
     };
 
@@ -12,8 +12,8 @@ function load(url) {
     csv.loadUrl(url, options, update, csv.TypeDeduction.KeepAll);
 }
 
-fetch('/conf.json').then(c => {
-    c.text().then(t => {
+fetch('/conf.json').then((c) => {
+    c.text().then((t) => {
         const json = JSON.parse(t);
         load(json.url);
     });

--- a/test/webpack-js/index.js
+++ b/test/webpack-js/index.js
@@ -7,7 +7,7 @@ const options = {
     delimiter: ',',
 };
 
-const update = progress => {
+const update = (progress) => {
     console.log('progress:', progress);
 };
 

--- a/test/webpack-ts/index.ts
+++ b/test/webpack-ts/index.ts
@@ -21,10 +21,10 @@ function onOpened(this: CSV, tag: string, columns: ColumnHeader[]): void {
     console.log(
         tag,
         `opened source, detected ${columns.length} columns:\n` +
-            columns.map(c => `${c.name}: ${DataType[c.type]}`).join('\n')
+            columns.map((c) => `${c.name}: ${DataType[c.type]}`).join('\n')
     );
     this.load({
-        columns: columns.map(c => c.type),
+        columns: columns.map((c) => c.type),
         generatedColumns: [],
     });
 }
@@ -48,7 +48,7 @@ function onDone(
 ): void {
     let columnsStats = '=== column stats: ===\n';
     columnsStats += columns
-        .map(c => {
+        .map((c) => {
             let text = `${c.name}: ${c.length} rows`;
             const asNum = c as NumberColumn;
             if (isNumber(c.type)) text += `, min ${asNum.min}, max ${asNum.max}`;
@@ -57,8 +57,8 @@ function onDone(
         .join('\n');
 
     const timeMS =
-        stats.performance.find(s => s.label === 'open').delta +
-        stats.performance.find(s => s.label === 'load').delta;
+        stats.performance.find((s) => s.label === 'open').delta +
+        stats.performance.find((s) => s.label === 'load').delta;
     const timeS = timeMS / 1000;
     const kB = stats.bytes / 1000;
     const rows = columns[0].length;
@@ -88,7 +88,7 @@ function onDone(
     console.log(tag, `done.\n${columnsStats}\n${loaderStats}`);
 
     console.groupCollapsed('=== performance stats: ===');
-    stats.performance.forEach(m => console.log(`${m.label}: ${m.delta} ms`));
+    stats.performance.forEach((m) => console.log(`${m.label}: ${m.delta} ms`));
     console.groupEnd();
 
     done();
@@ -113,16 +113,16 @@ function createLoader(tag: string, done: () => void): CSV {
 }
 
 function testUrl(tag: string, url: string): Promise<void> {
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve) => {
         createLoader(tag, resolve).open(url);
     });
 }
 
 function testGzipped(testCase: string, url: string): Promise<void> {
-    return new Promise<void>(resolve => {
+    return new Promise<void>((resolve) => {
         fetch(url)
-            .then(res => res.arrayBuffer())
-            .then(buf =>
+            .then((res) => res.arrayBuffer())
+            .then((buf) =>
                 createLoader(testCase, resolve).open(pako.inflate(new Uint8Array(buf)).buffer)
             );
     });

--- a/test/webpack-ts/webpack.config.js
+++ b/test/webpack-ts/webpack.config.js
@@ -44,7 +44,7 @@ export default function () {
             },
         },
         performance: {
-            assetFilter: assetFilename => !assetFilename.endsWith('.gz'),
+            assetFilter: (assetFilename) => !assetFilename.endsWith('.gz'),
         },
     };
 }


### PR DESCRIPTION
while the addition of prettier itself is a good thing, i dont agree with all rule proposals. i'm open to discussion, but i propose these rule changes:

- `arrowParens`: i'd prefer to have parantheses enabled, as this provides a clearer visual demarcation of the function arguments. especially for multiple parameters, i find it quicker to grasp the code when the params are grouped: `x, i => { log(x, i); }` vs `(x, i) => { log(x, i); }`
- `trailingComma`: personally, i find trailing commas confusing. it seems as if there's supposed to be another element that's missing.