### PR TITLE
style/import-sorter

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-    "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "mike-co.import-sorter"]
+    "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "dozerg.tsimportsorter"]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,17 +1,15 @@
 {
     "editor.formatOnSave": true,
     "editor.defaultFormatter": "esbenp.prettier-vscode",
-    "editor.codeActionsOnSave": {
-        "source.fixAll": true,
-        "source.organizeImports": false
-    },
     "editor.rulers": [100],
     "eslint.enable": true,
     "eslint.validate": ["javascript", "typescript"],
-    "importSorter.generalConfiguration.sortOnBeforeSave": true,
-    "importSorter.importStringConfiguration.maximumNumberOfImportExpressionsPerLine.type": "newLineEachExpressionAfterCountLimitExceptIfOnlyOne",
-    "importSorter.importStringConfiguration.maximumNumberOfImportExpressionsPerLine.count": 100,
-    "importSorter.importStringConfiguration.tabSize": 4,
-    "importSorter.importStringConfiguration.quoteMark": "single",
-    "importSorter.importStringConfiguration.trailingComma": "multiLine"
+    "tsImportSorter.configuration.autoFormat": "onSave",
+    "tsImportSorter.configuration.keepUnused": [".*"],
+    "tsImportSorter.configuration.wrappingStyle": "prettier",
+    "tsImportSorter.configuration.removeLastSlashInPath": true,
+    "tsImportSorter.configuration.groupRules": [
+        ["^react(-dom)?$", "^@angular/", "^vue$", "^node:", "^[@]", {}],
+        "^[.]"
+    ]
 }


### PR DESCRIPTION
This PR introduces a new VS Code extension for automatic import sorting.
The previous extension is not actively maintained and lacks of features newer TypeScript versions provide (namely type imports).
This new extension is actively maintained, does support the newest TypeScript features, and does even work for JS files as well. Additionally, it has a better interoperabillity with ESLint and Prettier.