### PR TITLE
feature/multiple-data-sources

### DIFF
--- a/src/csv.ts
+++ b/src/csv.ts
@@ -23,34 +23,56 @@ type EventType = `${Event}`;
 
 type ColumnHeader = { name: string; type: DataType };
 
-export class CSV {
+type InputData = Blob | File | ArrayBufferLike | Uint8Array | ReadableStream | string;
+
+export type DataSource = InputData | Promise<InputData> | (() => Promise<InputData>);
+
+export class CSV<D extends string> {
     protected _options: CsvLoaderOptions;
     protected _loader: Loader;
-    protected _handlers: Map<Event, Set<EventHandler>>;
+    protected _handlers: Map<EventType, Map<D, Set<EventHandler>>>;
 
-    public constructor(options: CsvLoaderOptions) {
-        this._options = Object.assign({}, options);
+    #openedDataSource: string;
+
+    public constructor(options: Partial<CsvLoaderOptions>) {
+        this._options = {
+            dataSources: {},
+            includesHeader: true,
+            typeInferLines: 20,
+            verbose: false,
+            ...options,
+        };
         this._loader = new Loader();
         this._loader.onOpened = this.dispatch.bind(this, Event.Opened);
         this._loader.onColumns = this.dispatch.bind(this, Event.Columns);
         this._loader.onData = this.dispatch.bind(this, Event.Data);
         this._loader.onDone = this.dispatch.bind(this, Event.Done);
         this._loader.onError = this.dispatch.bind(this, Event.Error);
-        this._handlers = new Map<Event, Set<EventHandler>>([
-            [Event.Opened, new Set<EventHandler>()],
-            [Event.Columns, new Set<EventHandler>()],
-            [Event.Data, new Set<EventHandler>()],
-            [Event.Done, new Set<EventHandler>()],
-            [Event.Error, new Set<EventHandler>()],
+        this._handlers = new Map<EventType, Map<D, Set<EventHandler>>>([
+            [Event.Opened, new Map()],
+            [Event.Columns, new Map()],
+            [Event.Data, new Map()],
+            [Event.Done, new Map()],
+            [Event.Error, new Map()],
         ]);
+
+        for (const id of Object.keys(this._options.dataSources)) {
+            this._handlers.forEach((handlerMap) => {
+                handlerMap.set(id as D, new Set());
+            });
+        }
     }
 
-    protected openFile(file: File): void {
+    protected openFile(file: Blob): void {
         this._options.size ??= file.size;
-        this._options.delimiter ??= deductDelimiter(file.name.split('.').pop());
+
+        if (file instanceof File) {
+            this._options.delimiter ??= deductDelimiter(file.name.split('.').pop());
+        }
+
         this._loader.options = this._options;
         this._loader.stream = file.stream();
-        this._loader.open();
+        this._loader.open(this.#openedDataSource);
     }
 
     protected openUrl(url: string): void {
@@ -62,47 +84,48 @@ export class CSV {
             }
             this._loader.options = this._options;
             this._loader.stream = res.body;
-            this._loader.open();
+            this._loader.open(this.#openedDataSource);
         });
     }
 
     protected openStream(stream: ReadableStream): void {
         this._loader.options = this._options;
         this._loader.stream = stream;
-        this._loader.open();
+        this._loader.open(this.#openedDataSource);
     }
 
     protected openBuffer(buffer: ArrayBufferLike): void {
         this._loader.options = this._options;
         this._loader.buffer = buffer;
-        this._loader.open();
+        this._loader.open(this.#openedDataSource);
     }
 
-    protected dispatch(event: Event, data: unknown): void {
-        const h = this._handlers.get(event);
+    protected dispatch(event: Event, id: D, data: unknown): void {
+        const h = this._handlers.get(event).get(id);
+
         switch (event) {
             case Event.Opened:
-                h.forEach((h) => (h as OpenedHandler)(data as ColumnHeader[]));
+                h.forEach((h) => (h as OpenedHandler)(id, data as ColumnHeader[]));
                 break;
             case Event.Columns:
-                h.forEach((h) => (h as ColumnsHandler)(data as Column[]));
+                h.forEach((h) => (h as ColumnsHandler)(id, data as Column[]));
                 break;
             case Event.Data:
-                h.forEach((h) => (h as DataHandler)(data as number));
+                h.forEach((h) => (h as DataHandler)(id, data as number));
                 break;
             case Event.Done:
-                h.forEach((h) => (h as DoneHandler)(data as LoadStatistics));
+                h.forEach((h) => (h as DoneHandler)(id, data as LoadStatistics));
                 break;
             case Event.Error:
-                h.forEach((h) => (h as ErrorHandler)(data as string));
+                h.forEach((h) => (h as ErrorHandler)(id, data as string));
                 break;
             default:
                 break;
         }
     }
 
-    public open(source: unknown): void {
-        if (source instanceof File) {
+    #openInputData(source: InputData): void {
+        if (source instanceof Blob) {
             this.openFile(source);
         } else if (typeof source === 'string') {
             this.openUrl(source);
@@ -117,17 +140,39 @@ export class CSV {
         }
     }
 
+    public async open(id: D): Promise<void> {
+        const dataSource: DataSource = this._options.dataSources[id];
+        const data = await (typeof dataSource === 'function' ? dataSource() : dataSource);
+
+        this.#openedDataSource = id;
+        this.#openInputData(data);
+    }
+
     public load(types: ColumnTypes): void {
         this._loader.types = types;
         this._loader.load();
     }
 
-    public on(event: EventType, handler: EventHandler): void {
-        this._handlers.get(event as Event).add(handler);
+    public on(event: EventType, id: D, handler: EventHandler): void {
+        this._handlers.get(event).get(id).add(handler);
     }
 
-    public off(event: EventType, handler: EventHandler): void {
-        this._handlers.get(event as Event).delete(handler);
+    public off(event: EventType, id: D, handler: EventHandler): void {
+        this._handlers.get(event).get(id).delete(handler);
+    }
+
+    public addDataSource(id: D, dataSource: DataSource): void {
+        this._options.dataSources[id] = dataSource;
+        this._handlers.forEach((handlerMap) => {
+            handlerMap.set(id, new Set());
+        });
+    }
+
+    public removeDataSource(id: D): void {
+        delete this._options.dataSources[id];
+        this._handlers.forEach((handlerMap) => {
+            handlerMap.delete(id);
+        });
     }
 }
 

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -12,6 +12,8 @@ import {
 } from './types/handlers';
 import { CsvLoaderOptions } from './types/options';
 
+import type { DataSource, InputData } from './types/dataSource';
+
 enum Event {
     Opened = 'opened',
     Columns = 'columns',
@@ -23,16 +25,12 @@ type EventType = `${Event}`;
 
 type ColumnHeader = { name: string; type: DataType };
 
-type InputData = Blob | File | ArrayBufferLike | Uint8Array | ReadableStream | string;
-
-export type DataSource = InputData | Promise<InputData> | (() => Promise<InputData>);
-
 export class CSV<D extends string> {
     protected _options: CsvLoaderOptions;
     protected _loader: Loader;
     protected _handlers: Map<EventType, Map<D, Set<EventHandler>>>;
 
-    #openedDataSource: string;
+    #openedDataSource: D;
 
     public constructor(options: Partial<CsvLoaderOptions>) {
         this._options = {
@@ -186,6 +184,9 @@ function deductDelimiter(format: string): string {
             return undefined;
     }
 }
+
+// re-export helpers
+export * from './helper/createDataSources';
 
 // re-export interface
 export * from './types/chunk/chunk';

--- a/src/csv.ts
+++ b/src/csv.ts
@@ -159,10 +159,10 @@ export class CSV<D extends string> {
         this._handlers.get(event).get(id).delete(handler);
     }
 
-    public addDataSource(id: D, dataSource: DataSource): void {
+    public addDataSource(id: string, dataSource: DataSource): void {
         this._options.dataSources[id] = dataSource;
         this._handlers.forEach((handlerMap) => {
-            handlerMap.set(id, new Set());
+            handlerMap.set(id as D, new Set());
         });
     }
 

--- a/src/helper/createDataSources.ts
+++ b/src/helper/createDataSources.ts
@@ -1,0 +1,14 @@
+import type { DataSource } from '../types/dataSource';
+
+/**
+ * This helper function is a Constrained Identity Function (CIF), which gives compiler hints if an
+ * invalid data source was used but retains the individual object keys as type.
+ *
+ * @param sources - An plain object with data sources.
+ * @returns The same plain object but with proper type annotations.
+ */
+export function createDataSources<DataSources extends Record<string, DataSource>>(
+    sources: DataSources
+): DataSources {
+    return sources;
+}

--- a/src/types/dataSource.ts
+++ b/src/types/dataSource.ts
@@ -1,0 +1,3 @@
+export type InputData = Blob | File | ArrayBufferLike | Uint8Array | ReadableStream | string;
+
+export type DataSource = InputData | Promise<InputData> | (() => Promise<InputData>);

--- a/src/types/handlers.ts
+++ b/src/types/handlers.ts
@@ -3,17 +3,17 @@ import { Column } from './column/column';
 import { DataType } from './dataType';
 
 export type ColumnHeader = { name: string; type: DataType };
-export type OpenedHandler = (detectedColumns: ColumnHeader[]) => void;
-export type ColumnsHandler = (columns: Column[]) => void;
-export type DataHandler = (progress: number) => void;
+export type OpenedHandler = (id: string, detectedColumns: ColumnHeader[]) => void;
+export type ColumnsHandler = (id: string, columns: Column[]) => void;
+export type DataHandler = (id: string, progress: number) => void;
 export type LoadStatistics = {
     chunks: number;
     bytes: number;
     workers: number;
     performance: Measurement[];
 };
-export type DoneHandler = (stats: LoadStatistics) => void;
-export type ErrorHandler = (msg: string) => void;
+export type DoneHandler = (id: string, stats: LoadStatistics) => void;
+export type ErrorHandler = (id: string, msg: string) => void;
 export type EventHandler =
     | OpenedHandler
     | ColumnsHandler

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,4 +1,4 @@
-import { DataSource } from '../csv';
+import type { DataSource } from './dataSource';
 
 export interface CsvLoaderOptions {
     dataSources: Record<string, DataSource>;

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -1,11 +1,11 @@
-export class CsvLoaderOptions {
-    public delimiter?: string;
-    public includesHeader = true;
-    public size?: number;
-    public typeInferLines = 20;
-    public verbose = false;
+import { DataSource } from '../csv';
 
-    public constructor(obj?: unknown) {
-        Object.assign(this, obj);
-    }
+export interface CsvLoaderOptions {
+    dataSources: Record<string, DataSource>;
+    includesHeader: boolean;
+    typeInferLines: number;
+    verbose: boolean;
+
+    delimiter?: string;
+    size?: number;
 }

--- a/test/webpack-ts/index.ts
+++ b/test/webpack-ts/index.ts
@@ -1,10 +1,18 @@
 import pako from 'pako';
 
-import { Column, ColumnHeader, CSV, DataType, isNumber, LoadStatistics } from '../..';
+import {
+    Column,
+    ColumnHeader,
+    createDataSources,
+    CSV,
+    DataType,
+    isNumber,
+    LoadStatistics,
+} from '../..';
 import { NumberColumn } from '../../lib/types/types/column/numberColumn';
 import conf from '../conf.json';
 
-const dataSources = {
+const dataSources = createDataSources({
     '[remote url stream]': conf.url,
     '[1m gzip buffer]': fetch(require('1m.csv.gz'))
         .then((res) => res.arrayBuffer())
@@ -12,7 +20,7 @@ const dataSources = {
     '[10m url stream]': require('10m.csv'),
     '[50m url stream]': require('50m.csv'),
     '[100m url stream]': require('100m.csv'),
-};
+});
 
 type DataSource = keyof typeof dataSources;
 

--- a/test/webpack-ts/index.ts
+++ b/test/webpack-ts/index.ts
@@ -1,25 +1,47 @@
 import pako from 'pako';
 
-import {
-    Column,
-    ColumnHeader,
-    CSV,
-    CsvLoaderOptions,
-    DataType,
-    isNumber,
-    LoadStatistics,
-} from '../..';
+import { Column, ColumnHeader, CSV, DataType, isNumber, LoadStatistics } from '../..';
 import { NumberColumn } from '../../lib/types/types/column/numberColumn';
 import conf from '../conf.json';
 
-const options = new CsvLoaderOptions({
+const dataSources = {
+    '[remote url stream]': conf.url,
+    '[1m gzip buffer]': fetch(require('1m.csv.gz'))
+        .then((res) => res.arrayBuffer())
+        .then((buf) => pako.inflate(new Uint8Array(buf)).buffer),
+    '[10m url stream]': require('10m.csv'),
+    '[50m url stream]': require('50m.csv'),
+    '[100m url stream]': require('100m.csv'),
+};
+
+type DataSource = keyof typeof dataSources;
+
+const loader = new CSV<DataSource>({
+    dataSources,
     includesHeader: true,
     delimiter: ',',
 });
 
-function onOpened(this: CSV, tag: string, columns: ColumnHeader[]): void {
+// Register event handlers
+for (const sourceId of Object.keys(dataSources) as DataSource[]) {
+    loader.on('opened', sourceId, onOpened.bind(loader));
+    loader.on('columns', sourceId, (id: string, columns: Column[]) => {
+        console.log(id, 'received columns');
+        loader.on('done', sourceId, onDone.bind(loader, columns));
+    });
+    loader.on('data', sourceId, (id: string, progress: number) => {
+        console.log(id, `received new data. progress: ${progress}`);
+    });
+    loader.on('error', sourceId, (id: string, msg: string) => {
+        console.log(id, 'error:', msg);
+    });
+}
+
+console.log('loader created');
+
+function onOpened(this: typeof loader, id: string, columns: ColumnHeader[]): void {
     console.log(
-        tag,
+        id,
         `opened source, detected ${columns.length} columns:\n` +
             columns.map((c) => `${c.name}: ${DataType[c.type]}`).join('\n')
     );
@@ -30,7 +52,7 @@ function onOpened(this: CSV, tag: string, columns: ColumnHeader[]): void {
 }
 
 type Stats = {
-    tag: string;
+    id: string;
     rows: number;
     kB: number;
     time: number;
@@ -39,13 +61,7 @@ type Stats = {
 };
 const statistics = new Array<Stats>();
 
-function onDone(
-    this: CSV,
-    tag: string,
-    done: () => void,
-    columns: Column[],
-    stats: LoadStatistics
-): void {
+function onDone(this: typeof loader, columns: Column[], id: string, stats: LoadStatistics): void {
     let columnsStats = '=== column stats: ===\n';
     columnsStats += columns
         .map((c) => {
@@ -57,15 +73,15 @@ function onDone(
         .join('\n');
 
     const timeMS =
-        stats.performance.find((s) => s.label === 'open').delta +
-        stats.performance.find((s) => s.label === 'load').delta;
+        stats.performance.find((s) => s.label === `${id}-open`).delta +
+        stats.performance.find((s) => s.label === `${id}-load`).delta;
     const timeS = timeMS / 1000;
     const kB = stats.bytes / 1000;
     const rows = columns[0].length;
     const kRows = rows / 1000;
 
     statistics.push({
-        tag,
+        id,
         rows,
         kB,
         time: timeS,
@@ -85,52 +101,23 @@ function onDone(
         `kB / s: ${(kB / timeS).toFixed(3)}\n` +
         `kRows / s: ${(kRows / timeS).toFixed(3)}\n`;
 
-    console.log(tag, `done.\n${columnsStats}\n${loaderStats}`);
+    console.log(id, `done.\n${columnsStats}\n${loaderStats}`);
 
     console.groupCollapsed('=== performance stats: ===');
     stats.performance.forEach((m) => console.log(`${m.label}: ${m.delta} ms`));
     console.groupEnd();
-
-    done();
 }
 
-function createLoader(tag: string, done: () => void): CSV {
-    const loader = new CSV(options);
-    loader.on('opened', onOpened.bind(loader, tag));
-    loader.on('columns', (columns: Column[]) => {
-        console.log(tag, 'received columns');
-        loader.on('done', onDone.bind(loader, tag, done, columns));
-    });
-    loader.on('data', (progress: number) => {
-        console.log(tag, `received new data. progress: ${progress}`);
-    });
-    loader.on('error', (msg: string) => {
-        console.log(tag, 'error:', msg);
-        done();
-    });
-    console.log(tag, 'created');
-    return loader;
-}
-
-function testUrl(tag: string, url: string): Promise<void> {
+function testLoad(id: DataSource): Promise<void> {
     return new Promise<void>((resolve) => {
-        createLoader(tag, resolve).open(url);
+        loader.on('done', id, () => resolve());
+        loader.open(id);
     });
 }
 
-function testGzipped(testCase: string, url: string): Promise<void> {
-    return new Promise<void>((resolve) => {
-        fetch(url)
-            .then((res) => res.arrayBuffer())
-            .then((buf) =>
-                createLoader(testCase, resolve).open(pako.inflate(new Uint8Array(buf)).buffer)
-            );
-    });
-}
-
-testUrl('[remote url stream]', conf.url)
-    .then(() => testGzipped('[1m gzip buffer]', require('1m.csv.gz')))
-    .then(() => testUrl('[10m url stream]', require('10m.csv')))
-    .then(() => testUrl('[50m url stream]', require('50m.csv')))
-    .then(() => testUrl('[100m url stream]', require('100m.csv')))
+testLoad('[remote url stream]')
+    .then(() => testLoad('[1m gzip buffer]'))
+    .then(() => testLoad('[10m url stream]'))
+    .then(() => testLoad('[50m url stream]'))
+    .then(() => testLoad('[100m url stream]'))
     .then(() => console.table(statistics));


### PR DESCRIPTION
This PR introduces _data sources_ that should enable loading data from different locations without creating new loader instances.
Data sources can be registered at instantiation in an options object or at runtime using `addDataSource()`. In order to use a data source, it can be opened with `loader.open(<id>)` by providing the ID that was used to register the source.
Additionally, the loader initialization options were refactored for simpler usage and better type inference with intellisense.