### PR TITLE
feature/google-sheets-datasource

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 lib
 test/data/*m.csv
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@typescript-eslint/eslint-plugin": "^5.4.0",
                 "@typescript-eslint/parser": "^5.4.0",
                 "concurrently": "^6.4.0",
+                "dotenv-webpack": "^7.0.3",
                 "eslint": "^8.3.0",
                 "eslint-config-prettier": "^8.3.0",
                 "eslint-plugin-prettier": "^4.0.0",
@@ -1861,6 +1862,39 @@
             "dependencies": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "node_modules/dotenv": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/dotenv-defaults": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+            "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+            "dev": true,
+            "dependencies": {
+                "dotenv": "^8.2.0"
+            }
+        },
+        "node_modules/dotenv-webpack": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz",
+            "integrity": "sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==",
+            "dev": true,
+            "dependencies": {
+                "dotenv-defaults": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "webpack": "^4 || ^5"
             }
         },
         "node_modules/ee-first": {
@@ -7561,6 +7595,30 @@
             "requires": {
                 "no-case": "^3.0.4",
                 "tslib": "^2.0.3"
+            }
+        },
+        "dotenv": {
+            "version": "8.6.0",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+            "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+            "dev": true
+        },
+        "dotenv-defaults": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/dotenv-defaults/-/dotenv-defaults-2.0.2.tgz",
+            "integrity": "sha512-iOIzovWfsUHU91L5i8bJce3NYK5JXeAwH50Jh6+ARUdLiiGlYWfGw6UkzsYqaXZH/hjE/eCd/PlfM/qqyK0AMg==",
+            "dev": true,
+            "requires": {
+                "dotenv": "^8.2.0"
+            }
+        },
+        "dotenv-webpack": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/dotenv-webpack/-/dotenv-webpack-7.0.3.tgz",
+            "integrity": "sha512-O0O9pOEwrk+n1zzR3T2uuXRlw64QxHSPeNN1GaiNBloQFNaCUL9V8jxSVz4jlXXFP/CIqK8YecWf8BAvsSgMjw==",
+            "dev": true,
+            "requires": {
+                "dotenv-defaults": "^2.0.2"
             }
         },
         "ee-first": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
         "@typescript-eslint/eslint-plugin": "^5.4.0",
         "@typescript-eslint/parser": "^5.4.0",
         "concurrently": "^6.4.0",
+        "dotenv-webpack": "^7.0.3",
         "eslint": "^8.3.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-prettier": "^4.0.0",

--- a/src/helper/spreadsheets.ts
+++ b/src/helper/spreadsheets.ts
@@ -1,0 +1,106 @@
+class CsvTransformer {
+    #isInValues = false;
+    #isInRow = false;
+    #resultChunk = '';
+
+    public start(): void {}
+    public flush(): void {}
+
+    public transform: TransformerTransformCallback<string, string> = (chunk, controller) => {
+        const searchString = `"values": [`;
+        const rows = chunk.split('\n');
+        let start = 0;
+
+        if (!this.#isInValues) {
+            if (chunk.includes(searchString)) {
+                this.#isInValues = true;
+                start = rows.findIndex((row) => row.trim() === searchString) + 1;
+            } else {
+                return;
+            }
+        }
+
+        for (const row of rows.slice(start)) {
+            const value = row.trim();
+
+            switch (value) {
+                case '[':
+                    this.#isInRow = true;
+                    break;
+
+                case '],':
+                case ']':
+                    if (!this.#isInRow) {
+                        controller.enqueue(this.#resultChunk);
+                        controller.terminate();
+                        return;
+                    }
+
+                    this.#resultChunk += '\n';
+                    this.#isInRow = false;
+                    break;
+
+                default:
+                    this.#resultChunk += value.replace(/"/g, '');
+                    break;
+            }
+        }
+
+        controller.enqueue(this.#resultChunk);
+        this.#resultChunk = '';
+    };
+}
+
+/**
+ * Gets the spreadsheet application specific name of a column from a number.
+ *
+ * Inspired by https://stackoverflow.com/questions/181596/how-to-convert-a-column-number-e-g-127-into-an-excel-column-e-g-aa.
+ *
+ * @param columnCount - Numeric representation of a column.
+ * @returns Application specific column name.
+ */
+function calculateEndColumn(columnCount: number): string {
+    const A = 'A'.charCodeAt(0);
+    let columnName = '';
+
+    while (columnCount > 0) {
+        const mod = (columnCount - 1) % 26;
+
+        columnName = String.fromCharCode(A + mod) + columnName;
+        columnCount = Math.trunc((columnCount - mod) / 26);
+    }
+
+    return columnName;
+}
+
+function fetchSheetData(route: string): Promise<Response> {
+    return fetch(`https://sheets.googleapis.com/v4/spreadsheets${route}`);
+}
+
+export async function fetchSheetDataRange(sheetId: string, apiKey: string): Promise<string> {
+    const route = `/${sheetId}?key=${apiKey}`;
+    const response = await fetchSheetData(route);
+    const { sheets } = await response.json();
+    const {
+        title,
+        gridProperties: { rowCount, columnCount },
+    } = sheets[0].properties;
+    const range = `${title}!A1:${calculateEndColumn(columnCount)}${rowCount}`;
+
+    return range;
+}
+
+export async function fetchSheetValues(
+    sheetId: string,
+    apiKey: string,
+    range: string
+): Promise<ReadableStream<Uint8Array>> {
+    const route = `/${sheetId}/values/${range}?key=${apiKey}`;
+    const response = await fetchSheetData(route);
+    const stream = response.body
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(new TransformStream(new CsvTransformer()))
+        .pipeThrough(new TextEncoderStream());
+
+    return stream;
+}

--- a/src/types/dataSource.ts
+++ b/src/types/dataSource.ts
@@ -1,3 +1,12 @@
-export type InputData = Blob | File | ArrayBufferLike | Uint8Array | ReadableStream | string;
+export type SheetInput = { apiKey: string; sheetId: string };
+
+export type InputData =
+    | Blob
+    | File
+    | ArrayBufferLike
+    | Uint8Array
+    | ReadableStream
+    | string
+    | SheetInput;
 
 export type DataSource = InputData | Promise<InputData> | (() => Promise<InputData>);

--- a/test/webpack-ts/index.ts
+++ b/test/webpack-ts/index.ts
@@ -12,6 +12,10 @@ const dataSources = {
     '[10m url stream]': require('10m.csv'),
     '[50m url stream]': require('50m.csv'),
     '[100m url stream]': require('100m.csv'),
+    '[google sheet]': {
+        apiKey: process.env.API_KEY,
+        sheetId: process.env.SHEET_ID,
+    },
 };
 
 type DataSource = keyof typeof dataSources;
@@ -120,4 +124,5 @@ testLoad('[remote url stream]')
     .then(() => testLoad('[10m url stream]'))
     .then(() => testLoad('[50m url stream]'))
     .then(() => testLoad('[100m url stream]'))
+    .then(() => testLoad('[google sheet]'))
     .then(() => console.table(statistics));

--- a/test/webpack-ts/webpack.config.js
+++ b/test/webpack-ts/webpack.config.js
@@ -1,3 +1,4 @@
+import DotenvPlugin from 'dotenv-webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 
 import { resolveFile } from '../../scripts/helper.js';
@@ -32,6 +33,7 @@ export default function () {
             },
         },
         plugins: [
+            new DotenvPlugin(),
             new HtmlWebpackPlugin({
                 filename: 'index.html',
                 template: './index.pug',


### PR DESCRIPTION
Depends on #8.
(It should be merged into main branch but the target is set to the branch base for better diff.)

This PR adds functionality to load table data from Google Spreadsheets.
As the spreadsheets API can only return the table values as JSON, a TransformStream is used to transform the incoming JSON stream into a suitable CSV format that can be processed by the CSV parser.