### PR TITLE
fix types and typos

### DIFF
--- a/apps/express/package.json
+++ b/apps/express/package.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "dependencies": {
         "@csv-parser/data": "1.0.0",
-        "@lukaswasgner/csv-parser": "^0.1.0",
+        "@lukaswagner/csv-parser": "^0.1.0",
         "express": "^4.17.2"
     }
 }

--- a/apps/vite-ts/package.json
+++ b/apps/vite-ts/package.json
@@ -21,7 +21,7 @@
         "@csv-parser/data": "1.0.0",
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
-        "@lukaswasgner/csv-parser": "^0.1.0",
+        "@lukaswagner/csv-parser": "^0.1.0",
         "framer-motion": "^4.1.17",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",

--- a/apps/vite-ts/src/api/loader.ts
+++ b/apps/vite-ts/src/api/loader.ts
@@ -1,4 +1,4 @@
-import { CSV } from '@lukaswasgner/csv-parser';
+import { CSV } from '@lukaswagner/csv-parser';
 
 export const loader = new CSV({
     delimiter: ',',

--- a/apps/vite-ts/src/components/DataTypeSelect.tsx
+++ b/apps/vite-ts/src/components/DataTypeSelect.tsx
@@ -1,5 +1,5 @@
 import { Box, Select, Text } from '@chakra-ui/react';
-import { DataType } from '@lukaswasgner/csv-parser';
+import { DataType } from '@lukaswagner/csv-parser';
 
 interface Props {
     label: string;

--- a/apps/webpack-js/package.json
+++ b/apps/webpack-js/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@csv-parser/data": "1.0.0",
-        "@lukaswasgner/csv-parser": "^0.1.0"
+        "@lukaswagner/csv-parser": "^0.1.0"
     },
     "devDependencies": {
         "html-webpack-plugin": "^5.5.0",

--- a/apps/webpack-ts/index.ts
+++ b/apps/webpack-ts/index.ts
@@ -3,11 +3,10 @@ import {
     Column,
     createDataSources,
     CSV,
-    DataType,
     isNumber,
     LoadStatistics,
-} from '@lukaswasgner/csv-parser';
-import { NumberColumn } from '@lukaswasgner/csv-parser/lib/types/types/column/numberColumn';
+    NumberColumn,
+} from '@lukaswagner/csv-parser';
 import pako from 'pako';
 
 const dataSources = createDataSources({
@@ -100,7 +99,7 @@ async function testLoad(id: DataSource): Promise<void> {
         console.log(
             id,
             `opened source, detected ${detectedColumns.length} columns:\n` +
-                detectedColumns.map(({ name, type }) => `${name}: ${DataType[type]}`).join('\n')
+                detectedColumns.map(({ name, type }) => `${name}: ${type}`).join('\n')
         );
 
         const [columns, dispatch] = loader.load({

--- a/apps/webpack-ts/package.json
+++ b/apps/webpack-ts/package.json
@@ -16,7 +16,7 @@
     },
     "dependencies": {
         "@csv-parser/data": "1.0.0",
-        "@lukaswasgner/csv-parser": "^0.1.0",
+        "@lukaswagner/csv-parser": "^0.1.0",
         "pako": "^2.0.4"
     },
     "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,8 @@
                 "typescript": "^4.5.2"
             },
             "engines": {
-                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "apps/data": {
@@ -37,7 +38,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "express": "^4.17.2"
             }
         },
@@ -54,7 +55,7 @@
                 "@csv-parser/data": "1.0.0",
                 "@emotion/react": "^11.7.1",
                 "@emotion/styled": "^11.6.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "framer-motion": "^4.1.17",
                 "react": "^17.0.2",
                 "react-dom": "^17.0.2",
@@ -418,7 +419,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0"
+                "@lukaswagner/csv-parser": "^0.1.0"
             },
             "devDependencies": {
                 "html-webpack-plugin": "^5.5.0",
@@ -433,7 +434,7 @@
             "license": "MIT",
             "dependencies": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "pako": "^2.0.4"
             },
             "devDependencies": {
@@ -1960,7 +1961,7 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "node_modules/@lukaswasgner/csv-parser": {
+        "node_modules/@lukaswagner/csv-parser": {
             "resolved": "packages/csv-parser",
             "link": true
         },
@@ -8614,7 +8615,7 @@
             }
         },
         "packages/csv-parser": {
-            "name": "@lukaswasgner/csv-parser",
+            "name": "@lukaswagner/csv-parser",
             "version": "0.1.0",
             "license": "MIT",
             "devDependencies": {
@@ -9605,7 +9606,7 @@
             "version": "file:apps/express",
             "requires": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "express": "^4.17.2"
             }
         },
@@ -9617,7 +9618,7 @@
                 "@csv-parser/data": "1.0.0",
                 "@emotion/react": "^11.7.1",
                 "@emotion/styled": "^11.6.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "@types/react": "^17.0.38",
                 "@types/react-dom": "^17.0.11",
                 "@types/wicg-file-system-access": "^2020.9.4",
@@ -9821,7 +9822,7 @@
             "version": "file:apps/webpack-js",
             "requires": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "html-webpack-plugin": "^5.5.0",
                 "webpack": "^5.65.0",
                 "webpack-cli": "^4.9.1",
@@ -9832,10 +9833,10 @@
             "version": "file:apps/webpack-ts",
             "requires": {
                 "@csv-parser/data": "1.0.0",
-                "@lukaswasgner/csv-parser": "^0.1.0",
+                "@lukaswagner/csv-parser": "^0.1.0",
                 "@types/pako": "^1.0.3",
                 "dotenv-webpack": "^7.0.3",
-                "html-loader": "*",
+                "html-loader": "^3.1.0",
                 "html-webpack-plugin": "^5.5.0",
                 "pako": "^2.0.4",
                 "pug": "^3.0.2",
@@ -10007,7 +10008,7 @@
             "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
             "dev": true
         },
-        "@lukaswasgner/csv-parser": {
+        "@lukaswagner/csv-parser": {
             "version": "file:packages/csv-parser",
             "requires": {
                 "@rollup/plugin-replace": "^3.0.1",

--- a/packages/csv-parser/package.json
+++ b/packages/csv-parser/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@lukaswasgner/csv-parser",
+    "name": "@lukaswagner/csv-parser",
     "version": "0.1.0",
     "description": "Multi-threaded CSV parser using web workers.",
     "type": "module",

--- a/packages/csv-parser/src/types/chunk/chunk.ts
+++ b/packages/csv-parser/src/types/chunk/chunk.ts
@@ -50,3 +50,7 @@ export function rebuildChunk(chunk: unknown): Chunk {
     const nc = buildChunk(oc._type, 0, 0);
     return Object.assign(nc, chunk);
 }
+
+export * from './colorChunk';
+export * from './numberChunk';
+export * from './stringChunk';

--- a/packages/csv-parser/src/types/column/column.ts
+++ b/packages/csv-parser/src/types/column/column.ts
@@ -55,3 +55,7 @@ export function rebuildColumn(column: unknown): Column {
     const nc = buildColumn(oc._name, oc._type);
     return Object.assign(nc, column);
 }
+
+export * from './colorColumn';
+export * from './numberColumn';
+export * from './stringColumn';

--- a/packages/csv-parser/src/types/dataType.ts
+++ b/packages/csv-parser/src/types/dataType.ts
@@ -1,15 +1,15 @@
 export enum DataType {
-    Number,
-    Int8,
-    Uint8,
-    Int16,
-    Uint16,
-    Int32,
-    Uint32,
-    Float32,
-    Float64,
-    Color,
-    String,
+    Number = 'number',
+    Int8 = 'int8',
+    Uint8 = 'uint8',
+    Int16 = 'int16',
+    Uint16 = 'uint16',
+    Int32 = 'int32',
+    Uint32 = 'uint32',
+    Float32 = 'float32',
+    Float64 = 'float64',
+    Color = 'color',
+    String = 'string',
 }
 
 export type ColumnGenerator = {


### PR DESCRIPTION
This PR
- fixes a typo in the library name
- adds typed columns and chunks to lib exports as they are required by other apps
- use string values for `DataType` enum for better console.log debug experience