### PR TITLE
multiple eol handling fixes

### DIFF
--- a/packages/csv-parser/src/helper/parseChunks.ts
+++ b/packages/csv-parser/src/helper/parseChunks.ts
@@ -13,7 +13,9 @@ function parseSingleChunk(chunk: ArrayBufferLike, start: Position, end: Position
     const decoder = new TextDecoder();
     const lines = new Array<string>();
     const buffer = new Uint8Array(chunk, start.char, end.char - start.char);
-    splitLines(decoder.decode(buffer), lines);
+    const remainder = splitLines(decoder.decode(buffer), lines);
+    // last chunk does not end with newline
+    lines.push(remainder);
     return lines;
 }
 

--- a/packages/csv-parser/src/worker/sub/interface.ts
+++ b/packages/csv-parser/src/worker/sub/interface.ts
@@ -12,6 +12,7 @@ export type StartData = {
     columns: DataType[];
     generatedColumns: ColumnGenerator[];
     options: SubWorkerOptions;
+    lastChunk: boolean;
 };
 
 export type FinishedData = {

--- a/packages/csv-parser/src/worker/sub/worker.ts
+++ b/packages/csv-parser/src/worker/sub/worker.ts
@@ -22,7 +22,7 @@ function onStart(data: Interface.StartData): void {
         splitLine(l, data.options.delimiter)
     );
 
-    const numChunks = lines.length + 1; // +1 for inter-chunk remainder
+    const numChunks = lines.length + +!data.lastChunk; // +1 for inter-chunk remainder
     const chunks = data.columns.map((c) => buildChunk(c, numChunks));
     const values = lines.map((l) => parseLine(l, data.columns));
     values.forEach((line, li) => line.forEach((value, vi) => storeValue(value, li, chunks[vi])));


### PR DESCRIPTION
- parseSingleChunk ignored the remainder, dropping the last line.
- The sub worker always allocated lines+1 to store the inter-chunk remainder. This is incorrect for the last chunk, as there's no remainder afterwards.
- The main worker tried to handle and store the inter-chunk remainders, but without rebuilding the chunks first, the store failed silently.
- Also renamed some variables in the main worker to be more intelligible.

closes #15