### PR TITLE
fix number of lines used for type inference

### DIFF
--- a/packages/csv-parser/src/loader.ts
+++ b/packages/csv-parser/src/loader.ts
@@ -128,7 +128,11 @@ export class Loader {
         const inferStart = +this._options.includesHeader;
         const inferLines = this._firstChunkSplit.slice(
             inferStart,
-            Math.max(inferStart + this._options.typeInferLines, this._firstChunkSplit.length)
+            Math.min(
+                inferStart + this._options.typeInferLines,
+                // avoid last line, could be split between chunks
+                this._firstChunkSplit.length - 1
+            )
         );
 
         const detectedTypes = inferLines


### PR DESCRIPTION
- use min to choose line count instead of max
- avoid last line, as it could be split between chunks and contain incomplete data