### PR TITLE
feat: add Excel data source

### DIFF
--- a/apps/vite-ts/src/components/DataSourceOpener.tsx
+++ b/apps/vite-ts/src/components/DataSourceOpener.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { DeleteIcon } from '@chakra-ui/icons';
-import { Box, Button, Center, IconButton, Spinner, Stack } from '@chakra-ui/react';
+import { Box, Button, Center, Spinner, Stack } from '@chakra-ui/react';
+import { ColumnHeader, DataType } from '@lukaswagner/csv-parser';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 
 import { loader } from '../api/loader';
@@ -17,7 +17,6 @@ import {
 import { isRemote } from '../utils/datasources';
 import { Card } from './Card';
 import { DataTypeSelect } from './DataTypeSelect';
-import { ColumnHeader, DataType } from '@lukaswagner/csv-parser';
 
 const isLocal = (dataSource: DataSource, inputData: InputData): inputData is File =>
     dataSource === 'local';
@@ -163,12 +162,13 @@ export const DataSourceOpener = (): JSX.Element => {
                     ) : (
                         <Stack gap={2}>
                             <Box display="flex" justifyContent="end">
-                                <IconButton
+                                <Button
                                     aria-label="Reset column headers"
                                     colorScheme="gray"
-                                    icon={<DeleteIcon />}
                                     onClick={handleResetClick}
-                                />
+                                >
+                                    Reset
+                                </Button>
                             </Box>
                             {columns.map((column, index) => (
                                 <DataTypeSelect

--- a/apps/vite-ts/src/components/DataSourceSelect.tsx
+++ b/apps/vite-ts/src/components/DataSourceSelect.tsx
@@ -9,18 +9,16 @@ import {
     InputLeftAddon,
     InputRightElement,
     RadioGroup,
-    Select,
     Stack,
     Text,
     useBoolean,
 } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
 
-import { type DataSource, dataSourceState, inputDataState, type Sheet } from '../store/app';
+import { type DataSource, dataSourceState, inputDataState } from '../store/app';
 import { isRemote, isSheet } from '../utils/datasources';
 import { FileIcon } from './icons/FileIcon';
 import { KeyIcon } from './icons/KeyIcon';
-import { SheetIcon } from './icons/SheetIcon';
 import { SelectionCard } from './SelectionCard';
 
 export const DataSourceSelect = (): JSX.Element => {
@@ -74,27 +72,17 @@ export const DataSourceSelect = (): JSX.Element => {
         }));
     };
 
-    const handleSheetsTypeChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
-        setInputData((currVal) => ({
-            apiKey: isSheet(currVal) ? currVal.apiKey : '',
-            sheetId: isSheet(currVal) ? currVal.sheetId : '',
-            type: event.target.value as Sheet['type'],
-        }));
-    };
-
     const handleSheetsApiKeyChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setInputData((currVal) => ({
             apiKey: event.target.value,
-            sheetId: isSheet(currVal) ? currVal.sheetId : '',
-            type: isSheet(currVal) ? currVal.type : 'google',
+            sheetUrl: isSheet(currVal) ? currVal.sheetUrl : '',
         }));
     };
 
-    const handleSheetsSheetIdChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
+    const handleSheetsSheetUrlChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setInputData((currVal) => ({
             apiKey: isSheet(currVal) ? currVal.apiKey : '',
-            sheetId: event.target.value,
-            type: isSheet(currVal) ? currVal.type : 'google',
+            sheetUrl: event.target.value,
         }));
     };
 
@@ -154,17 +142,9 @@ export const DataSourceSelect = (): JSX.Element => {
                 <SelectionCard
                     isChecked={dataSource === 'sheets'}
                     onClick={handleDataSourceSelect}
-                    title="Google Sheets / Excel"
+                    title="Google / Excel Sheets"
                     value="sheets"
                 >
-                    <Select
-                        onChange={handleSheetsTypeChange}
-                        placeholder="Select sheets service"
-                        value={isSheet(inputData) ? inputData.type : ''}
-                    >
-                        <option value="google">Google Sheets</option>
-                        <option value="excel">Excel Sheets</option>
-                    </Select>
                     <InputGroup>
                         <InputLeftAddon>
                             <KeyIcon />
@@ -187,13 +167,13 @@ export const DataSourceSelect = (): JSX.Element => {
                     </InputGroup>
                     <InputGroup>
                         <InputLeftAddon>
-                            <SheetIcon />
+                            <LinkIcon />
                         </InputLeftAddon>
                         <Input
-                            onChange={handleSheetsSheetIdChange}
-                            placeholder="Sheet ID"
+                            onChange={handleSheetsSheetUrlChange}
+                            placeholder="Sheet URL"
                             type="text"
-                            value={isSheet(inputData) ? inputData.sheetId : ''}
+                            value={isSheet(inputData) ? inputData.sheetUrl : ''}
                         />
                     </InputGroup>
                 </SelectionCard>

--- a/apps/vite-ts/src/components/DataSourceSelect.tsx
+++ b/apps/vite-ts/src/components/DataSourceSelect.tsx
@@ -9,6 +9,7 @@ import {
     InputLeftAddon,
     InputRightElement,
     RadioGroup,
+    Stack,
     Text,
     useBoolean,
 } from '@chakra-ui/react';
@@ -87,88 +88,97 @@ export const DataSourceSelect = (): JSX.Element => {
     };
 
     return (
-        <RadioGroup onChange={handleDataSourceSelect} value={dataSource}>
-            <SelectionCard
-                isChecked={dataSource === 'local'}
-                onClick={handleDataSourceSelect}
-                title="Local"
-                value="local"
-            >
-                <Button colorScheme="gray" leftIcon={<FileIcon />} onClick={handleOpenFileClick}>
-                    Open file
-                </Button>
-                <Input
-                    ref={fileInput}
-                    accept="text/csv"
-                    multiple={false}
-                    display="none"
-                    onChange={handleFileInputChange}
-                    type="file"
-                />
-                {inputData instanceof File ? <Text>Opened file: {inputData.name}</Text> : null}
-            </SelectionCard>
-            <SelectionCard
-                isChecked={dataSource === 'remote'}
-                onClick={handleDataSourceSelect}
-                title="Remote"
-                value="remote"
-            >
-                <InputGroup>
-                    <InputLeftAddon>
-                        <LinkIcon />
-                    </InputLeftAddon>
-                    <Input
-                        onChange={handleRemoteUrlChange}
-                        placeholder="URL"
-                        type="url"
-                        value={isRemote(inputData) ? inputData.url : ''}
-                    />
-                </InputGroup>
-                <Checkbox
-                    onChange={handleRemotePrefetchChange}
-                    isChecked={isRemote(inputData) ? inputData.shouldPrefetch : false}
+        <Stack gap={4}>
+            <Text fontSize="md" fontWeight={500} lineHeight="40px">
+                Select data source:
+            </Text>
+            <RadioGroup onChange={handleDataSourceSelect} value={dataSource}>
+                <SelectionCard
+                    isChecked={dataSource === 'local'}
+                    onClick={handleDataSourceSelect}
+                    title="Local"
+                    value="local"
                 >
-                    Prefetch data
-                </Checkbox>
-            </SelectionCard>
-            <SelectionCard
-                isChecked={dataSource === 'google-sheets'}
-                onClick={handleDataSourceSelect}
-                title="Google Sheets"
-                value="google-sheets"
-            >
-                <InputGroup>
-                    <InputLeftAddon>
-                        <KeyIcon />
-                    </InputLeftAddon>
+                    <Button
+                        colorScheme="gray"
+                        leftIcon={<FileIcon />}
+                        onClick={handleOpenFileClick}
+                    >
+                        Open file
+                    </Button>
                     <Input
-                        onChange={handleSheetsApiKeyChange}
-                        placeholder="API Key"
-                        type={showApiKey ? 'text' : 'password'}
-                        value={isSheet(inputData) ? inputData.apiKey : ''}
+                        ref={fileInput}
+                        accept="text/csv"
+                        multiple={false}
+                        display="none"
+                        onChange={handleFileInputChange}
+                        type="file"
                     />
-                    <InputRightElement>
-                        <IconButton
-                            aria-label="Show API key"
-                            colorScheme="gray"
-                            icon={showApiKey ? <ViewOffIcon /> : <ViewIcon />}
-                            onClick={setShowApiKey.toggle}
-                            variant="ghost"
+                    {inputData instanceof File ? <Text>Opened file: {inputData.name}</Text> : null}
+                </SelectionCard>
+                <SelectionCard
+                    isChecked={dataSource === 'remote'}
+                    onClick={handleDataSourceSelect}
+                    title="Remote"
+                    value="remote"
+                >
+                    <InputGroup>
+                        <InputLeftAddon>
+                            <LinkIcon />
+                        </InputLeftAddon>
+                        <Input
+                            onChange={handleRemoteUrlChange}
+                            placeholder="URL"
+                            type="url"
+                            value={isRemote(inputData) ? inputData.url : ''}
                         />
-                    </InputRightElement>
-                </InputGroup>
-                <InputGroup>
-                    <InputLeftAddon>
-                        <SheetIcon />
-                    </InputLeftAddon>
-                    <Input
-                        onChange={handleSheetsSheetIdChange}
-                        placeholder="Sheet ID"
-                        type="text"
-                        value={isSheet(inputData) ? inputData.sheetId : ''}
-                    />
-                </InputGroup>
-            </SelectionCard>
-        </RadioGroup>
+                    </InputGroup>
+                    <Checkbox
+                        onChange={handleRemotePrefetchChange}
+                        isChecked={isRemote(inputData) ? inputData.shouldPrefetch : false}
+                    >
+                        Prefetch data
+                    </Checkbox>
+                </SelectionCard>
+                <SelectionCard
+                    isChecked={dataSource === 'google-sheets'}
+                    onClick={handleDataSourceSelect}
+                    title="Google Sheets"
+                    value="google-sheets"
+                >
+                    <InputGroup>
+                        <InputLeftAddon>
+                            <KeyIcon />
+                        </InputLeftAddon>
+                        <Input
+                            onChange={handleSheetsApiKeyChange}
+                            placeholder="API Key"
+                            type={showApiKey ? 'text' : 'password'}
+                            value={isSheet(inputData) ? inputData.apiKey : ''}
+                        />
+                        <InputRightElement>
+                            <IconButton
+                                aria-label="Show API key"
+                                colorScheme="gray"
+                                icon={showApiKey ? <ViewOffIcon /> : <ViewIcon />}
+                                onClick={setShowApiKey.toggle}
+                                variant="ghost"
+                            />
+                        </InputRightElement>
+                    </InputGroup>
+                    <InputGroup>
+                        <InputLeftAddon>
+                            <SheetIcon />
+                        </InputLeftAddon>
+                        <Input
+                            onChange={handleSheetsSheetIdChange}
+                            placeholder="Sheet ID"
+                            type="text"
+                            value={isSheet(inputData) ? inputData.sheetId : ''}
+                        />
+                    </InputGroup>
+                </SelectionCard>
+            </RadioGroup>
+        </Stack>
     );
 };

--- a/apps/vite-ts/src/components/DataSourceSelect.tsx
+++ b/apps/vite-ts/src/components/DataSourceSelect.tsx
@@ -9,13 +9,14 @@ import {
     InputLeftAddon,
     InputRightElement,
     RadioGroup,
+    Select,
     Stack,
     Text,
     useBoolean,
 } from '@chakra-ui/react';
 import { useRecoilState } from 'recoil';
 
-import { type DataSource, dataSourceState, inputDataState } from '../store/app';
+import { type DataSource, dataSourceState, inputDataState, type Sheet } from '../store/app';
 import { isRemote, isSheet } from '../utils/datasources';
 import { FileIcon } from './icons/FileIcon';
 import { KeyIcon } from './icons/KeyIcon';
@@ -73,10 +74,19 @@ export const DataSourceSelect = (): JSX.Element => {
         }));
     };
 
+    const handleSheetsTypeChange = (event: React.ChangeEvent<HTMLSelectElement>): void => {
+        setInputData((currVal) => ({
+            apiKey: isSheet(currVal) ? currVal.apiKey : '',
+            sheetId: isSheet(currVal) ? currVal.sheetId : '',
+            type: event.target.value as Sheet['type'],
+        }));
+    };
+
     const handleSheetsApiKeyChange = (event: React.ChangeEvent<HTMLInputElement>): void => {
         setInputData((currVal) => ({
             apiKey: event.target.value,
             sheetId: isSheet(currVal) ? currVal.sheetId : '',
+            type: isSheet(currVal) ? currVal.type : 'google',
         }));
     };
 
@@ -84,6 +94,7 @@ export const DataSourceSelect = (): JSX.Element => {
         setInputData((currVal) => ({
             apiKey: isSheet(currVal) ? currVal.apiKey : '',
             sheetId: event.target.value,
+            type: isSheet(currVal) ? currVal.type : 'google',
         }));
     };
 
@@ -141,11 +152,19 @@ export const DataSourceSelect = (): JSX.Element => {
                     </Checkbox>
                 </SelectionCard>
                 <SelectionCard
-                    isChecked={dataSource === 'google-sheets'}
+                    isChecked={dataSource === 'sheets'}
                     onClick={handleDataSourceSelect}
-                    title="Google Sheets"
-                    value="google-sheets"
+                    title="Google Sheets / Excel"
+                    value="sheets"
                 >
+                    <Select
+                        onChange={handleSheetsTypeChange}
+                        placeholder="Select sheets service"
+                        value={isSheet(inputData) ? inputData.type : ''}
+                    >
+                        <option value="google">Google Sheets</option>
+                        <option value="excel">Excel Sheets</option>
+                    </Select>
                     <InputGroup>
                         <InputLeftAddon>
                             <KeyIcon />

--- a/apps/vite-ts/src/components/Header.tsx
+++ b/apps/vite-ts/src/components/Header.tsx
@@ -41,8 +41,7 @@ export const Header = (): JSX.Element => {
             setDataSource('sheets');
             setInputData({
                 apiKey: import.meta.env.VITE_GOOGLE_API_KEY,
-                sheetId: import.meta.env.VITE_GOOGLE_SHEET_ID,
-                type: 'google',
+                sheetUrl: import.meta.env.VITE_GOOGLE_SHEET_URL,
             });
         });
     };
@@ -54,8 +53,7 @@ export const Header = (): JSX.Element => {
             setDataSource('sheets');
             setInputData({
                 apiKey: import.meta.env.VITE_EXCEL_API_KEY,
-                sheetId: import.meta.env.VITE_EXCEL_SHEET_ID,
-                type: 'excel',
+                sheetUrl: import.meta.env.VITE_EXCEL_SHEET_URL,
             });
         });
     };
@@ -76,11 +74,11 @@ export const Header = (): JSX.Element => {
             </Text>
             {conf.url ? <Button onClick={handleRemoteUrlClick}>Remote URL</Button> : null}
 
-            {import.meta.env.VITE_GOOGLE_API_KEY && import.meta.env.VITE_GOOGLE_SHEET_ID ? (
+            {import.meta.env.VITE_GOOGLE_API_KEY && import.meta.env.VITE_GOOGLE_SHEET_URL ? (
                 <Button onClick={handleGoogleSheetClick}>Google Sheet</Button>
             ) : null}
 
-            {import.meta.env.VITE_EXCEL_API_KEY && import.meta.env.VITE_EXCEL_SHEET_ID ? (
+            {import.meta.env.VITE_EXCEL_API_KEY && import.meta.env.VITE_EXCEL_SHEET_URL ? (
                 <Button onClick={handleExcelSheetClick}>Excel Sheet</Button>
             ) : null}
             <Spacer />

--- a/apps/vite-ts/src/components/Header.tsx
+++ b/apps/vite-ts/src/components/Header.tsx
@@ -38,10 +38,24 @@ export const Header = (): JSX.Element => {
         handleResetClick();
 
         setTimeout(() => {
-            setDataSource('google-sheets');
+            setDataSource('sheets');
             setInputData({
-                apiKey: import.meta.env.VITE_API_KEY,
-                sheetId: import.meta.env.VITE_SHEET_ID,
+                apiKey: import.meta.env.VITE_GOOGLE_API_KEY,
+                sheetId: import.meta.env.VITE_GOOGLE_SHEET_ID,
+                type: 'google',
+            });
+        });
+    };
+
+    const handleExcelSheetClick = (): void => {
+        handleResetClick();
+
+        setTimeout(() => {
+            setDataSource('sheets');
+            setInputData({
+                apiKey: import.meta.env.VITE_EXCEL_API_KEY,
+                sheetId: import.meta.env.VITE_EXCEL_SHEET_ID,
+                type: 'excel',
             });
         });
     };
@@ -62,8 +76,12 @@ export const Header = (): JSX.Element => {
             </Text>
             {conf.url ? <Button onClick={handleRemoteUrlClick}>Remote URL</Button> : null}
 
-            {import.meta.env.VITE_API_KEY && import.meta.env.VITE_SHEET_ID ? (
+            {import.meta.env.VITE_GOOGLE_API_KEY && import.meta.env.VITE_GOOGLE_SHEET_ID ? (
                 <Button onClick={handleGoogleSheetClick}>Google Sheet</Button>
+            ) : null}
+
+            {import.meta.env.VITE_EXCEL_API_KEY && import.meta.env.VITE_EXCEL_SHEET_ID ? (
+                <Button onClick={handleExcelSheetClick}>Excel Sheet</Button>
             ) : null}
             <Spacer />
             <Button colorScheme="gray" onClick={handleResetClick}>

--- a/apps/vite-ts/src/components/Header.tsx
+++ b/apps/vite-ts/src/components/Header.tsx
@@ -1,4 +1,3 @@
-import { DeleteIcon } from '@chakra-ui/icons';
 import { Button, Flex, Spacer, Text } from '@chakra-ui/react';
 import conf from '@csv-parser/data/conf.json';
 import { useResetRecoilState, useSetRecoilState } from 'recoil';
@@ -67,7 +66,7 @@ export const Header = (): JSX.Element => {
                 <Button onClick={handleGoogleSheetClick}>Google Sheet</Button>
             ) : null}
             <Spacer />
-            <Button colorScheme="gray" leftIcon={<DeleteIcon />} onClick={handleResetClick}>
+            <Button colorScheme="gray" onClick={handleResetClick}>
                 Reset
             </Button>
         </Flex>

--- a/apps/vite-ts/src/components/InputTypeSelect.tsx
+++ b/apps/vite-ts/src/components/InputTypeSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { RadioGroup } from '@chakra-ui/react';
+import { RadioGroup, Stack, Text } from '@chakra-ui/react';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { type InputType, inputTypeState, isInputTypeDisabledState } from '../store/app';
@@ -28,16 +28,21 @@ export const InputTypeSelect = (): JSX.Element => {
     };
 
     return (
-        <RadioGroup isDisabled={isDisabled} onChange={handleInputTypeSelect} value={inputType}>
-            {inputTypes.map(({ title, value }) => (
-                <SelectionCard
-                    key={`input-type-${value}`}
-                    isDisabled={isDisabled}
-                    onClick={handleInputTypeSelect}
-                    title={title}
-                    value={value}
-                />
-            ))}
-        </RadioGroup>
+        <Stack gap={4}>
+            <Text fontSize="md" fontWeight={500} lineHeight="40px" opacity={isDisabled ? 0.5 : 1}>
+                Select input type:
+            </Text>
+            <RadioGroup isDisabled={isDisabled} onChange={handleInputTypeSelect} value={inputType}>
+                {inputTypes.map(({ title, value }) => (
+                    <SelectionCard
+                        key={`input-type-${value}`}
+                        isDisabled={isDisabled}
+                        onClick={handleInputTypeSelect}
+                        title={title}
+                        value={value}
+                    />
+                ))}
+            </RadioGroup>
+        </Stack>
     );
 };

--- a/apps/vite-ts/src/components/icons/SheetIcon.ts
+++ b/apps/vite-ts/src/components/icons/SheetIcon.ts
@@ -1,7 +1,0 @@
-import { createIcon } from '@chakra-ui/icons';
-
-export const SheetIcon = createIcon({
-    displayName: 'SheetIcon',
-    viewBox: '0 0 24 24',
-    d: 'M10 10.02h5V21h-5V10.02zM17 21h3c1.1 0 2-.9 2-2v-9h-5v11zm3-18H5c-1.1 0-2 .9-2 2v3h19V5c0-1.1-.9-2-2-2zM3 19c0 1.1.9 2 2 2h3V10H3v9z',
-});

--- a/apps/vite-ts/src/env.d.ts
+++ b/apps/vite-ts/src/env.d.ts
@@ -2,9 +2,9 @@
 
 interface ImportMetaEnv {
     readonly VITE_GOOGLE_API_KEY: string;
-    readonly VITE_GOOGLE_SHEET_ID: string;
+    readonly VITE_GOOGLE_SHEET_URL: string;
     readonly VITE_EXCEL_API_KEY: string;
-    readonly VITE_EXCEL_SHEET_ID: string;
+    readonly VITE_EXCEL_SHEET_URL: string;
 }
 
 interface ImportMeta {

--- a/apps/vite-ts/src/env.d.ts
+++ b/apps/vite-ts/src/env.d.ts
@@ -1,8 +1,10 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-    readonly VITE_API_KEY: string;
-    readonly VITE_SHEET_ID: string;
+    readonly VITE_GOOGLE_API_KEY: string;
+    readonly VITE_GOOGLE_SHEET_ID: string;
+    readonly VITE_EXCEL_API_KEY: string;
+    readonly VITE_EXCEL_SHEET_ID: string;
 }
 
 interface ImportMeta {

--- a/apps/vite-ts/src/store/app.ts
+++ b/apps/vite-ts/src/store/app.ts
@@ -7,7 +7,7 @@ export type DataSource = 'local' | 'remote' | 'sheets';
 
 export type Remote = { url: string; shouldPrefetch: boolean };
 
-export type Sheet = { apiKey: string; sheetId: string; type: 'google' | 'excel' };
+export type Sheet = { apiKey: string; sheetUrl: string };
 
 export type InputData = File | Remote | Sheet;
 
@@ -66,8 +66,7 @@ export const isOpenerDisabledState = selector({
             (dataSource === 'sheets' &&
                 isSheet(inputData) &&
                 !!inputData.apiKey &&
-                !!inputData.sheetId &&
-                ['google', 'excel'].includes(inputData.type)) ||
+                !!inputData.sheetUrl) ||
             (dataSource !== 'sheets' && inputData);
 
         return !dataSource || (requiresType && !inputType) || !hasData;

--- a/apps/vite-ts/src/store/app.ts
+++ b/apps/vite-ts/src/store/app.ts
@@ -3,11 +3,11 @@ import { atom, selector } from 'recoil';
 
 import { isRemote, isSheet } from '../utils/datasources';
 
-export type DataSource = 'local' | 'remote' | 'google-sheets';
+export type DataSource = 'local' | 'remote' | 'sheets';
 
 export type Remote = { url: string; shouldPrefetch: boolean };
 
-export type Sheet = { apiKey: string; sheetId: string };
+export type Sheet = { apiKey: string; sheetId: string; type: 'google' | 'excel' };
 
 export type InputData = File | Remote | Sheet;
 
@@ -62,8 +62,15 @@ export const isOpenerDisabledState = selector({
         const requiresType =
             dataSource === 'local' ||
             (dataSource === 'remote' && isRemote(inputData) && inputData.shouldPrefetch);
+        const hasData =
+            (dataSource === 'sheets' &&
+                isSheet(inputData) &&
+                !!inputData.apiKey &&
+                !!inputData.sheetId &&
+                ['google', 'excel'].includes(inputData.type)) ||
+            (dataSource !== 'sheets' && inputData);
 
-        return !dataSource || (requiresType && !inputType) || !inputData;
+        return !dataSource || (requiresType && !inputType) || !hasData;
     },
 });
 

--- a/apps/vite-ts/src/utils/datasources.ts
+++ b/apps/vite-ts/src/utils/datasources.ts
@@ -4,4 +4,4 @@ export const isRemote = (data: InputData | undefined): data is Remote =>
     typeof data === 'object' && 'url' in data;
 
 export const isSheet = (data: InputData | undefined): data is Sheet =>
-    typeof data === 'object' && 'sheetId' in data;
+    typeof data === 'object' && 'sheetUrl' in data;

--- a/apps/webpack-ts/index.ts
+++ b/apps/webpack-ts/index.ts
@@ -10,9 +10,9 @@ import {
 import pako from 'pako';
 
 const googleSheetAvailable =
-    process.env.GOOGLE_API_KEY !== undefined && process.env.GOOGLE_SHEET_ID !== undefined;
+    process.env.GOOGLE_API_KEY !== undefined && process.env.GOOGLE_SHEET_URL !== undefined;
 const excelSheetAvailable =
-    process.env.EXCEL_API_KEY !== undefined && process.env.EXCEL_SHEET_ID !== undefined;
+    process.env.EXCEL_API_KEY !== undefined && process.env.EXCEL_SHEET_URL !== undefined;
 
 const dataSources = createDataSources({
     '[remote url stream]': conf.url,
@@ -24,14 +24,12 @@ const dataSources = createDataSources({
     '[5m url stream]': require('5m.csv'),
     '[10m url stream]': require('10m.csv'),
     '[google sheet]': {
-        type: 'google',
         apiKey: process.env.GOOGLE_API_KEY,
-        sheetId: process.env.GOOGLE_SHEET_ID,
+        sheetUrl: process.env.GOOGLE_SHEET_URL,
     },
     '[excel sheet]': {
-        type: 'excel',
         apiKey: process.env.EXCEL_API_KEY,
-        sheetId: process.env.EXCEL_SHEET_ID,
+        sheetUrl: process.env.EXCEL_SHEET_URL,
     },
 });
 

--- a/apps/webpack-ts/index.ts
+++ b/apps/webpack-ts/index.ts
@@ -9,7 +9,10 @@ import {
 } from '@lukaswagner/csv-parser';
 import pako from 'pako';
 
-const sheetAvailable = process.env.API_KEY !== undefined && process.env.SHEET_ID !== undefined;
+const googleSheetAvailable =
+    process.env.GOOGLE_API_KEY !== undefined && process.env.GOOGLE_SHEET_ID !== undefined;
+const excelSheetAvailable =
+    process.env.EXCEL_API_KEY !== undefined && process.env.EXCEL_SHEET_ID !== undefined;
 
 const dataSources = createDataSources({
     '[remote url stream]': conf.url,
@@ -21,8 +24,14 @@ const dataSources = createDataSources({
     '[5m url stream]': require('5m.csv'),
     '[10m url stream]': require('10m.csv'),
     '[google sheet]': {
-        apiKey: process.env.API_KEY,
-        sheetId: process.env.SHEET_ID,
+        type: 'google',
+        apiKey: process.env.GOOGLE_API_KEY,
+        sheetId: process.env.GOOGLE_SHEET_ID,
+    },
+    '[excel sheet]': {
+        type: 'excel',
+        apiKey: process.env.EXCEL_API_KEY,
+        sheetId: process.env.EXCEL_SHEET_ID,
     },
 });
 
@@ -131,5 +140,6 @@ testLoad('[remote url stream]')
     .then(() => testLoad('[1m gzip buffer]'))
     .then(() => testLoad('[5m url stream]'))
     .then(() => testLoad('[10m url stream]'))
-    .then(() => (sheetAvailable ? testLoad('[google sheet]') : Promise.resolve()))
+    .then(() => (googleSheetAvailable ? testLoad('[google sheet]') : Promise.resolve()))
+    .then(() => (excelSheetAvailable ? testLoad('[excel sheet]') : Promise.resolve()))
     .then(() => console.table(statistics));

--- a/packages/csv-parser/src/csv.ts
+++ b/packages/csv-parser/src/csv.ts
@@ -1,4 +1,5 @@
-import { fetchSheetDataRange, fetchSheetValues } from './helper/spreadsheets';
+import * as excel from './helper/excel-sheets';
+import * as google from './helper/spreadsheets';
 import { Loader } from './loader';
 import type { Column } from './types/column/column';
 import type { DataSource, InputData, SheetInput } from './types/dataSource';
@@ -65,18 +66,16 @@ export class CSV<D extends string> {
     }
 
     protected async openSheet(data: SheetInput): Promise<ColumnHeader[]> {
-        const { apiKey, sheetId } = data;
+        const { apiKey, sheetId, type } = data;
+        const sheetService = type === 'google' ? google : excel;
 
         // Determine range specifier for sheet area that is filled with data
-        const range = await fetchSheetDataRange(sheetId, apiKey);
+        const range = await sheetService.fetchSheetDataRange(sheetId, apiKey);
 
         // Fetch sheet values as stream
-        const stream = await fetchSheetValues(sheetId, apiKey, range);
+        const stream = await sheetService.fetchSheetValues(sheetId, apiKey, range);
 
         this._options.delimiter ??= deductDelimiter('csv');
-
-        // TODO: Determine data length ?
-
         this._loader.options = this._options;
         this._loader.stream = stream;
 

--- a/packages/csv-parser/src/csv.ts
+++ b/packages/csv-parser/src/csv.ts
@@ -1,5 +1,4 @@
-import * as excel from './helper/excel-sheets';
-import * as google from './helper/google-sheets';
+import { excel, google, parseSheetId } from './helper/spreadsheets';
 import { Loader } from './loader';
 import type { Column } from './types/column/column';
 import type { DataSource, InputData, SheetInput } from './types/dataSource';
@@ -66,7 +65,8 @@ export class CSV<D extends string> {
     }
 
     protected async openSheet(data: SheetInput): Promise<ColumnHeader[]> {
-        const { apiKey, sheetId, type } = data;
+        const { apiKey, sheetUrl } = data;
+        const { sheetId, type } = parseSheetId(sheetUrl);
         const sheetService = type === 'google' ? google : excel;
 
         // Determine range specifier for sheet area that is filled with data
@@ -95,7 +95,7 @@ export class CSV<D extends string> {
             source instanceof Uint8Array
         ) {
             return this.openBuffer(source);
-        } else if ('sheetId' in source && 'apiKey' in source) {
+        } else if ('sheetUrl' in source && 'apiKey' in source) {
             return this.openSheet(source);
         }
     }

--- a/packages/csv-parser/src/csv.ts
+++ b/packages/csv-parser/src/csv.ts
@@ -1,5 +1,5 @@
 import * as excel from './helper/excel-sheets';
-import * as google from './helper/spreadsheets';
+import * as google from './helper/google-sheets';
 import { Loader } from './loader';
 import type { Column } from './types/column/column';
 import type { DataSource, InputData, SheetInput } from './types/dataSource';

--- a/packages/csv-parser/src/helper/excel-sheets.ts
+++ b/packages/csv-parser/src/helper/excel-sheets.ts
@@ -1,0 +1,94 @@
+class ExcelCsvTransformer {
+    protected _isInValues = false;
+    protected _isInRow = false;
+    protected _resultChunk = '';
+
+    public start(): void {}
+    public flush(): void {}
+
+    public transform: TransformerTransformCallback<string, string> = (chunk, controller) => {
+        const searchString = `"text":[`;
+        let start = 0;
+
+        if (!this._isInValues) {
+            const searchIndex = chunk.indexOf(searchString);
+
+            if (searchIndex >= 0) {
+                this._isInValues = true;
+                start = searchIndex + searchString.length;
+            } else {
+                return;
+            }
+        }
+
+        for (const char of chunk.substring(start)) {
+            switch (char) {
+                case '[':
+                    this._isInRow = true;
+                    break;
+
+                case ']':
+                    if (!this._isInRow) {
+                        controller.enqueue(this._resultChunk);
+                        controller.terminate();
+                        return;
+                    }
+
+                    this._resultChunk += '\n';
+                    this._isInRow = false;
+                    break;
+
+                case '"':
+                    // Ignore string quotes
+                    break;
+
+                case ',':
+                    if (!this._isInRow) {
+                        // Ignore comma between rows
+                        break;
+                    }
+
+                // fallthrough
+
+                default:
+                    this._resultChunk += char;
+                    break;
+            }
+        }
+
+        controller.enqueue(this._resultChunk);
+        this._resultChunk = '';
+    };
+}
+
+function fetchSheetData(route: string, apiToken: string): Promise<Response> {
+    const headers = new Headers();
+
+    headers.set('Authorization', `Bearer ${apiToken}`);
+
+    return fetch(`https://graph.microsoft.com/v1.0/me/drive/items${route}`, { headers });
+}
+
+export async function fetchSheetDataRange(sheetId: string, apiToken: string): Promise<string> {
+    const route = `/${sheetId}/workbook/worksheets`;
+    const response = await fetchSheetData(route, apiToken);
+    const { value: sheets } = await response.json();
+    const { name } = sheets[0];
+
+    return name;
+}
+
+export async function fetchSheetValues(
+    sheetId: string,
+    apiToken: string,
+    tableName: string
+): Promise<ReadableStream<Uint8Array>> {
+    const route = `/${sheetId}/workbook/worksheets('${tableName}')/usedRange?$select=text`;
+    const response = await fetchSheetData(route, apiToken);
+    const stream = response.body
+        .pipeThrough(new TextDecoderStream())
+        .pipeThrough(new TransformStream(new ExcelCsvTransformer()))
+        .pipeThrough(new TextEncoderStream());
+
+    return stream;
+}

--- a/packages/csv-parser/src/helper/google-sheets.ts
+++ b/packages/csv-parser/src/helper/google-sheets.ts
@@ -1,4 +1,4 @@
-class CsvTransformer {
+class GoogleCsvTransformer {
     protected _isInValues = false;
     protected _isInRow = false;
     protected _resultChunk = '';
@@ -99,7 +99,7 @@ export async function fetchSheetValues(
     const response = await fetchSheetData(route);
     const stream = response.body
         .pipeThrough(new TextDecoderStream())
-        .pipeThrough(new TransformStream(new CsvTransformer()))
+        .pipeThrough(new TransformStream(new GoogleCsvTransformer()))
         .pipeThrough(new TextEncoderStream());
 
     return stream;

--- a/packages/csv-parser/src/helper/spreadsheets.ts
+++ b/packages/csv-parser/src/helper/spreadsheets.ts
@@ -1,0 +1,28 @@
+import type { SheetType } from '../types/dataSource';
+
+export function parseSheetId(sheetUrl: string): { type: SheetType; sheetId: string } {
+    const url = new URL(sheetUrl);
+    let type: SheetType;
+    let sheetId: string;
+
+    switch (url.host) {
+        case 'docs.google.com':
+            type = 'google';
+            // Getting ID out of /spreadsheets/d/<sheet-id>/edit
+            [, , , sheetId] = url.pathname.split('/');
+            break;
+
+        case 'onedrive.live.com':
+            type = 'excel';
+            sheetId = url.searchParams.get('resid');
+            break;
+
+        default:
+            throw new Error('Invalid url for spreadsheet service');
+    }
+
+    return { type, sheetId };
+}
+
+export * as google from './google-sheets';
+export * as excel from './excel-sheets';

--- a/packages/csv-parser/src/types/dataSource.ts
+++ b/packages/csv-parser/src/types/dataSource.ts
@@ -1,4 +1,4 @@
-export type SheetInput = { apiKey: string; sheetId: string };
+export type SheetInput = { apiKey: string; sheetId: string; type: 'google' | 'excel' };
 
 export type InputData =
     | Blob

--- a/packages/csv-parser/src/types/dataSource.ts
+++ b/packages/csv-parser/src/types/dataSource.ts
@@ -1,4 +1,6 @@
-export type SheetInput = { apiKey: string; sheetId: string; type: 'google' | 'excel' };
+export type SheetType = 'google' | 'excel';
+
+export type SheetInput = { apiKey: string; sheetUrl: string };
 
 export type InputData =
     | Blob


### PR DESCRIPTION
This PR adds support for Excel sheets as data source using the Microsoft Graph API. Furthermore, the API was adapted to use an URL to deduct the spreadsheet service and parse the sheed ID from the URL at once.
The Vite test app is extended to support Google and Excel sheets. The webpack-ts test app is extended by a additional Excel test case.
Additionally, some minor UI changes for the Vite test app are added.