### PR TITLE
refactor: improve load method API

### DIFF
--- a/apps/express/index.js
+++ b/apps/express/index.js
@@ -11,18 +11,12 @@ async function loadDataSource(id) {
     const detectedColumns = await loader.open(id);
     console.log(id, 'opened, found', detectedColumns.length, 'columns');
 
-    const [, dispatch] = loader.load({
-        columns: detectedColumns.map(({ type }) => type),
-        generatedColumns: [],
+    await loader.load({
+        columns: detectedColumns,
+        onUpdate: (progress) => console.log(id, `received new data. progress: ${progress}`),
     });
 
-    for await (const value of dispatch()) {
-        if (value.type === 'data') {
-            console.log(id, `received new data. progress: ${value.progress}`);
-        } else {
-            console.log(id, 'done');
-        }
-    }
+    console.log(id, 'done');
 }
 
 async function load() {

--- a/apps/vite-ts/src/components/DataSourceLoader.tsx
+++ b/apps/vite-ts/src/components/DataSourceLoader.tsx
@@ -12,6 +12,7 @@ import {
     Thead,
     Tr,
 } from '@chakra-ui/react';
+import { DataType, NumberColumn } from '@lukaswagner/csv-parser';
 import { useRecoilState, useRecoilValue } from 'recoil';
 
 import { loader } from '../api/loader';
@@ -23,7 +24,6 @@ import {
     statisticsState,
 } from '../store/app';
 import { Card } from './Card';
-import { DataType, NumberColumn } from '@lukaswagner/csv-parser';
 
 export const DataSourceLoader = (): JSX.Element => {
     const isDisabled = useRecoilValue(isLoaderDisabledState);
@@ -44,21 +44,16 @@ export const DataSourceLoader = (): JSX.Element => {
         setIsLoading(true);
         setShowCard(true);
 
-        const [columns, dispatch] = loader.load({
-            columns: columnHeaders.map(({ type }) => type),
-            generatedColumns: [],
+        const { columns: resultColumns, statistics } = await loader.load({
+            columns: columnHeaders,
         });
 
-        for await (const value of dispatch()) {
-            if (value.type === 'done') {
-                console.log({ columns, statistics: value.statistics });
+        console.log({ resultColumns, statistics });
 
-                setColumns(columns);
-                setStatistics(value.statistics);
+        setColumns(resultColumns);
+        setStatistics(statistics);
 
-                setIsLoading(false);
-            }
-        }
+        setIsLoading(false);
     };
 
     return (

--- a/apps/webpack-js/index.js
+++ b/apps/webpack-js/index.js
@@ -13,18 +13,12 @@ async function load() {
     const detectedColumns = await loader.open('data');
     console.log('opened');
 
-    const [, dispatch] = loader.load({
-        columns: detectedColumns.map(({ type }) => type),
-        generatedColumns: [],
+    await loader.load({
+        columns: detectedColumns,
+        onUpdate: (progress) => console.log(`received new data. progress: ${progress}`),
     });
 
-    for await (const value of dispatch()) {
-        if (value.type === 'data') {
-            console.log(`received new data. progress: ${value.progress}`);
-        } else {
-            console.log('done');
-        }
-    }
+    console.log('done');
 }
 
 load();

--- a/apps/webpack-ts/index.ts
+++ b/apps/webpack-ts/index.ts
@@ -104,32 +104,20 @@ async function testLoad(id: DataSource): Promise<void> {
     try {
         const detectedColumns = await loader.open(id);
 
-        // onOpened
         console.log(
             id,
             `opened source, detected ${detectedColumns.length} columns:\n` +
                 detectedColumns.map(({ name, type }) => `${name}: ${type}`).join('\n')
         );
 
-        const [columns, dispatch] = loader.load({
-            columns: detectedColumns.map(({ type }) => type),
-            generatedColumns: [],
+        const { columns, statistics } = await loader.load({
+            columns: detectedColumns,
+            onInit: () => console.log(id, 'received columns'),
+            onUpdate: (progress) => console.log(id, `received new data. progress: ${progress}`),
         });
 
-        // onColumns
-        console.log(id, 'received columns');
-
-        for await (const value of dispatch()) {
-            if (value.type === 'data') {
-                // onData
-                console.log(id, `received new data. progress: ${value.progress}`);
-            } else {
-                // onDone
-                logResult(columns, id, value.statistics);
-            }
-        }
+        logResult(columns, id, statistics);
     } catch (error) {
-        // onError
         console.log(id, 'error:', error);
     }
 }

--- a/packages/csv-parser/src/csv.ts
+++ b/packages/csv-parser/src/csv.ts
@@ -1,10 +1,8 @@
 import { excel, google, parseSheetId } from './helper/spreadsheets';
 import { Loader } from './loader';
-import type { Column } from './types/column/column';
 import type { DataSource, InputData, SheetInput } from './types/dataSource';
-import type { ColumnTypes } from './types/dataType';
-import type { ColumnHeader, Dispatcher } from './types/handlers';
-import type { CsvLoaderOptions } from './types/options';
+import type { ColumnHeader, LoadResult } from './types/handlers';
+import type { CsvLoaderOptions, LoadOptions } from './types/options';
 
 export class CSV<D extends string> {
     protected _openedDataSource: D;
@@ -109,8 +107,8 @@ export class CSV<D extends string> {
         return this.openInputData(data);
     }
 
-    public load(types: ColumnTypes): [Column[], Dispatcher] {
-        this._loader.types = types;
+    public load(options: LoadOptions): Promise<LoadResult> {
+        this._loader.loadOptions = options;
 
         return this._loader.load();
     }

--- a/packages/csv-parser/src/loader.ts
+++ b/packages/csv-parser/src/loader.ts
@@ -4,9 +4,8 @@ import { PerfMon } from './helper/perfMon';
 import { splitLine } from './helper/splitLine';
 import { AnyChunk, rebuildChunk } from './types/chunk/chunk';
 import { buildColumn, Column } from './types/column/column';
-import { ColumnTypes } from './types/dataType';
-import type { ColumnHeader, Dispatcher, DispatchValue, LoadStatistics } from './types/handlers';
-import { CsvLoaderOptions } from './types/options';
+import type { ColumnHeader, LoadResult, LoadStatistics } from './types/handlers';
+import { CsvLoaderOptions, LoadOptions } from './types/options';
 import {
     AddChunkData,
     FinishedData,
@@ -24,11 +23,11 @@ export class Loader {
     protected _buffer: ArrayBufferLike;
     protected _openedSourceId: string;
     protected _options: CsvLoaderOptions;
+    protected _loadOptions: LoadOptions;
 
     protected _reader: ReadableStreamDefaultReader<Uint8Array>;
     protected _firstChunk: ArrayBuffer;
     protected _firstChunkSplit: string[][];
-    protected _types: ColumnTypes;
     protected _columns: Column[];
     protected _worker: Worker;
     protected _perfMon = new PerfMon();
@@ -151,7 +150,7 @@ export class Loader {
 
     protected setupColumns(): Column[] {
         this._columns = [
-            ...this._types.columns.map((type, index) =>
+            ...this._loadOptions.columns.map(({ type }, index) =>
                 buildColumn(
                     this._options.includesHeader
                         ? this._firstChunkSplit[0][index]
@@ -159,69 +158,65 @@ export class Loader {
                     type
                 )
             ),
-            ...this._types.generatedColumns.map(({ name, type }) => buildColumn(name, type)),
+            ...(this._loadOptions.generatedColumns ?? []).map(({ name, type }) =>
+                buildColumn(name, type)
+            ),
         ];
         this._firstChunkSplit = undefined;
 
         return this._columns;
     }
 
-    protected setupWorker(): ReadableStream<DispatchValue> {
-        class WorkerSource {
-            public constructor(private readonly loader: Loader) {}
+    protected setupWorker(): Promise<LoadStatistics> {
+        return new Promise((resolve, reject) => {
+            this._worker = new Worker(
+                // @ts-expect-error The path to the worker source is only during build.
+                new URL(__MAIN_WORKER_SOURCE, import.meta.url),
+                { type: 'module' }
+            );
 
-            public start(controller: ReadableStreamController<DispatchValue>): void {
-                this.loader._worker = new Worker(
-                    // @ts-expect-error The path to the worker source is only during build.
-                    new URL(__MAIN_WORKER_SOURCE, import.meta.url),
-                    { type: 'module' }
-                );
+            this._worker.onmessage = (event: MessageEvent<MessageData>) => {
+                const message = event.data;
+                switch (message.type) {
+                    case MessageType.Processed: {
+                        const progress = this.onProcessed(message.data as ProcessedData);
 
-                this.loader._worker.onmessage = (event: MessageEvent<MessageData>) => {
-                    const message = event.data;
-                    switch (message.type) {
-                        case MessageType.Processed:
-                            controller.enqueue({
-                                type: 'data',
-                                progress: this.loader.onProcessed(message.data as ProcessedData),
-                            });
-                            break;
-                        case MessageType.Finished:
-                            controller.enqueue({
-                                type: 'done',
-                                statistics: this.loader.onFinished(message.data as FinishedData),
-                            });
-                            this.loader._worker.terminate();
-                            controller.close();
-                            break;
-                        default:
-                            if (this.loader._options.verbose)
-                                console.log('received invalid msg from main worker:', message);
-
-                            controller.error(['received invalid msg from main worker:', message]);
-                            break;
+                        this._loadOptions.onUpdate?.(progress);
+                        break;
                     }
-                };
 
-                const setup: SetupData = {
-                    columns: this.loader._types.columns,
-                    generatedColumns: this.loader._types.generatedColumns,
-                    options: {
-                        delimiter: this.loader._options.delimiter,
-                        includesHeader: this.loader._options.includesHeader,
-                        verbose: this.loader._options.verbose,
-                    },
-                };
-                const message: MessageData = {
-                    type: MessageType.Setup,
-                    data: setup,
-                };
+                    case MessageType.Finished: {
+                        this._worker.terminate();
+                        resolve(this.onFinished(message.data as FinishedData));
+                        break;
+                    }
 
-                this.loader._worker.postMessage(message);
-            }
-        }
+                    default: {
+                        if (this._options.verbose)
+                            console.log('received invalid msg from main worker:', message);
 
-        return new ReadableStream(new WorkerSource(this));
+                        reject(['received invalid msg from main worker:', message]);
+                        break;
+                    }
+                }
+            };
+
+            const setup: SetupData = {
+                columns: this._loadOptions.columns.map((column) => column.type),
+                generatedColumns: this._loadOptions.generatedColumns ?? [],
+                options: {
+                    delimiter: this._options.delimiter,
+                    includesHeader: this._options.includesHeader,
+                    verbose: this._options.verbose,
+                },
+            };
+            const message: MessageData = {
+                type: MessageType.Setup,
+                data: setup,
+            };
+
+            this._worker.postMessage(message);
+        });
     }
 
     protected onProcessed(data: ProcessedData): number {
@@ -277,22 +272,14 @@ export class Loader {
         }
     }
 
-    public load(): [Column[], Dispatcher] {
+    public async load(): Promise<LoadResult> {
         this._perfMon.start(`${this._openedSourceId}-load`);
 
         const columns = this.setupColumns();
-        const resultStream = this.setupWorker();
-        const dispatch = async function* (): AsyncGenerator<DispatchValue, void> {
-            const reader = resultStream.getReader();
 
-            while (true) {
-                const { done, value } = await reader.read();
+        this._loadOptions.onInit?.(columns);
 
-                if (done) return;
-
-                yield value;
-            }
-        };
+        const statistics = this.setupWorker();
 
         if (this._stream) {
             this.readStreamFirstChunk();
@@ -300,7 +287,7 @@ export class Loader {
             this.readBuffer();
         }
 
-        return [columns, dispatch];
+        return { columns, statistics: await statistics };
     }
 
     public set stream(stream: ReadableStream) {
@@ -315,7 +302,7 @@ export class Loader {
         this._options = options;
     }
 
-    public set types(columns: ColumnTypes) {
-        this._types = columns;
+    public set loadOptions(options: LoadOptions) {
+        this._loadOptions = options;
     }
 }

--- a/packages/csv-parser/src/types/dataType.ts
+++ b/packages/csv-parser/src/types/dataType.ts
@@ -19,11 +19,6 @@ export type ColumnGenerator = {
     func: (orig: string[], parsed: unknown[]) => unknown;
 };
 
-export type ColumnTypes = {
-    columns: DataType[];
-    generatedColumns: ColumnGenerator[];
-};
-
 export function bytes(type: DataType): number {
     switch (type) {
         case DataType.Int8:

--- a/packages/csv-parser/src/types/handlers.ts
+++ b/packages/csv-parser/src/types/handlers.ts
@@ -1,5 +1,6 @@
-import { Measurement } from '../helper/perfMon';
-import { DataType } from './dataType';
+import type { Measurement } from '../helper/perfMon';
+import type { Column } from './column/column';
+import type { DataType } from './dataType';
 
 export type ColumnHeader = { name: string; type: DataType };
 export type LoadStatistics = {
@@ -9,8 +10,4 @@ export type LoadStatistics = {
     performance: Measurement[];
 };
 
-export type DispatchValue =
-    | { type: 'data'; progress: number }
-    | { type: 'done'; statistics: LoadStatistics };
-
-export type Dispatcher = () => AsyncGenerator<DispatchValue, void>;
+export type LoadResult = { columns: Column[]; statistics: LoadStatistics };

--- a/packages/csv-parser/src/types/options.ts
+++ b/packages/csv-parser/src/types/options.ts
@@ -1,4 +1,7 @@
+import type { Column } from './column/column';
 import type { DataSource } from './dataSource';
+import type { ColumnGenerator } from './dataType';
+import type { ColumnHeader } from './handlers';
 
 export interface CsvLoaderOptions {
     dataSources: Record<string, DataSource>;
@@ -9,3 +12,10 @@ export interface CsvLoaderOptions {
     delimiter?: string;
     size?: number;
 }
+
+export type LoadOptions = {
+    columns: ColumnHeader[];
+    generatedColumns?: ColumnGenerator[];
+    onInit?: (columns: Column[]) => void;
+    onUpdate?: (progress: number) => void;
+};


### PR DESCRIPTION
This PR changes the API of the `load()` method.
Changes include:

- return promise with columns and statistics

- use onInit and onUpdate callbacks

- simplify load options

BREAKING CHANGE: `load()`  returns a promise with an object, which destructures to `{ columns, statistics }`, rather than an array of `columns` and a `dispatcher`

Closes https://github.com/lukaswagner/csv-parser/issues/32